### PR TITLE
Added GitHub CI build and push images version 14,15,16

### DIFF
--- a/.github/workflows/.github-ci.yml
+++ b/.github/workflows/.github-ci.yml
@@ -1,1 +1,45 @@
 name: Docker Image CI
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker-build-release:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - { postgres: 14, alpine: '3.16' }
+          - { postgres: 15, alpine: '3.17' }
+          - { postgres: 16, alpine: '3.19' }
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.CI_REGISTRY_USER }}
+          password: ${{ secrets.CI_REGISTRY_TOKEN }}
+
+      - name: Builds and pushes Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_IMAGE }}:${{ matrix.postgres }}
+          build-args: |
+            ALPINE_VERSION=${{ matrix.alpine }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
- Added GitHub CI build and push images version 14,15,16
- Github CI ran successfully on my fork, please check [here](https://github.com/trants/postgres-backup/actions/runs/7334946788) 
